### PR TITLE
Fixing minor bugs in loading datasets

### DIFF
--- a/he_utdebug.py
+++ b/he_utdebug.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
     
     test_lookup, gen_test_lookup, problem_lookup = {}, {}, {}
     
-    problems = load_dataset(HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
+    problems = load_dataset('json', data_files=HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
 
 
     problems = problems.map(extract_test, keep_in_memory=True)

--- a/mbpp_intrinsic_eval.py
+++ b/mbpp_intrinsic_eval.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
      #
     test_lookup = {}
-    if not args.hard:
+    if args.hard:
         problems = load_dataset('json', data_files=HF_DATASET["mbpp_plus_fix_hard"])['train']
     else:
         problems = load_dataset('json', data_files=HF_DATASET["mbpp_plus_fix"])['train']

--- a/mbpp_utdebug.py
+++ b/mbpp_utdebug.py
@@ -365,13 +365,12 @@ if __name__ == "__main__":
                     tensor_parallel_size=torch.cuda.device_count(),
                     tokenizer=model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    code_src = load_dataset('json', data_files=[args.source])['train']
 
 
     print(colored(f"Found {len(code_src)} instances...", 'yellow'))
     test_lookup, gen_test_lookup, problem_lookup = {}, {}, {}
     
-    problems = load_dataset(HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
+    problems = load_dataset('json', data_files=HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
     
     problems = problems.map(extract_test, keep_in_memory=True)
     problems = problems.map(build_problem_lookup, keep_in_memory=True)

--- a/no_ut_he.py
+++ b/no_ut_he.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 
     test_lookup, gen_test_lookup, problem_lookup = {}, {}, {}
     
-    problems = load_dataset(HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
+    problems = load_dataset('json', data_files=HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
 
     problems = problems.map(extract_test, keep_in_memory=True)
 

--- a/no_ut_mbpp.py
+++ b/no_ut_mbpp.py
@@ -274,7 +274,7 @@ if __name__ == "__main__":
 
     test_lookup, gen_test_lookup, problem_lookup = {}, {}, {}
 
-    problems = load_dataset(HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
+    problems = load_dataset('json', data_files=HF_DATASET[args.dataset], cache_dir=".cache/datasets")['train'] 
 
     problems = problems.map(extract_test, keep_in_memory=True)
     problems = problems.map(build_problem_lookup, keep_in_memory=True)


### PR DESCRIPTION
1. `load_dataset(HF_DATASET[args.dataset], ...)` -> `load_dataset('json', data_files=HF_DATASET[args.dataset], ...)` for each evaluation code
2. Current `mbpp_intrinsic_eval.py` loads hard dataset when `not args.hard`. Fixed this.
3. In `mbpp_utdebug.py`, unused `code_src = load_dataset(...)` variable exists and makes an error. Removed this.